### PR TITLE
Handle PDFs for external links by disabling the link, not attempting to download

### DIFF
--- a/fle_site/apps/ka_lite/management/commands/download_user_resource_files.py
+++ b/fle_site/apps/ka_lite/management/commands/download_user_resource_files.py
@@ -16,7 +16,8 @@ class Command(NoArgsCommand):
             os.makedirs(user_resource_path)
 
         for res in UserResource.objects.all():
-            url = res.get_google_download_url()
-            path = res.get_download_path()
-            path, msg = urllib.urlretrieve(url, path)
-            self.stdout.write("Downloaded %s to %s\n\n" % (url, path))
+            if res.is_google_doc:
+                url = res.get_google_download_url()
+                path = res.get_download_path()
+                path, msg = urllib.urlretrieve(url, path)
+                self.stdout.write("Downloaded %s to %s\n\n" % (url, path))

--- a/fle_site/apps/ka_lite/templates/ka_lite/user-guides.html
+++ b/fle_site/apps/ka_lite/templates/ka_lite/user-guides.html
@@ -37,19 +37,27 @@
                                         <td class="col-xs-4">
                                             {{ g.title }}
                                         </td>
-                                        <td class="col-xs-4 center-text">
-                                            {% if g.is_google_doc %}
+                                        {% if g.is_google_doc %}
+                                            <td class="col-xs-4 center-text">
                                                 <a href="{% url 'user_guide_detail' g.slug %}">
-                                            {% else %}
+                                                <span class="glyphicon glyphicon-eye-open"></span>&nbsp;View Online</a>
+                                            </td>
+                                            <td class="col-xs-4">
+                                                <a href="{{ g.get_download_url }}" class="pull-right">
+                                                    <span class="glyphicon glyphicon-file"></span>&nbsp;PDF
+                                                </a>
+                                            </td>
+                                        {% else %}
+                                            <td class="col-xs-4 center-text">
                                                 <a href="{{ g.external_url }}">
-                                            {% endif %}
-                                            <span class="glyphicon glyphicon-eye-open"></span>&nbsp;View Online</a>
-                                        </td>
-                                        <td class="col-xs-4">
-                                            <a href="{{ g.get_download_url }}" class="pull-right">
-                                                <span class="glyphicon glyphicon-file"></span>&nbsp;PDF
-                                            </a>
-                                        </td>
+                                                <span class="glyphicon glyphicon-eye-open"></span>&nbsp;View Online</a>
+                                            </td>
+                                            <td class="col-xs-4">
+                                                <span class="pull-right unavailable">
+                                                    <s>&nbsp;PDF</s>
+                                                </span>
+                                            </td>
+                                        {% endif %}
                                     </tr>
                                 {% endfor %}
                             </tbody>


### PR DESCRIPTION
Once a docs builder server is up and running we can amend this to look for a PDF. For now, the simplest case simply seems to be to disable downloading the PDF. See screenshot:

![ss](https://cloud.githubusercontent.com/assets/8888020/7145622/7c1106b0-e2a2-11e4-9a46-5c53a0a89339.png)
