### PR TITLE
fix mobile background img change height relative to address bar

### DIFF
--- a/fle_site/apps/main/static/css/kickstarter.css
+++ b/fle_site/apps/main/static/css/kickstarter.css
@@ -280,7 +280,6 @@ header {
   -o-background-size: cover;
   text-align: center;
   color: white;
-  height: 100vh;
 }
 header .intro-text {
   height: 0;
@@ -311,7 +310,6 @@ header .intro-text .intro-heading {
   padding: 100px 0;
 }
 .header-shadow {
-  height: 70vh;
   z-index: 2;
   background: -moz-linear-gradient(top, rgba(0,0,0,0.7) 0%, rgba(0,0,0,0) 100%); /* FF3.6+ */
   background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(0,0,0,0.7)), color-stop(100%,rgba(0,0,0,0))); /* Chrome,Safari5+ */

--- a/fle_site/apps/main/static/kickstarter/kickstarter_mobile_template.html
+++ b/fle_site/apps/main/static/kickstarter/kickstarter_mobile_template.html
@@ -1,1 +1,29 @@
+<STYLE type="text/css">
+    @media all and (orientation:portrait) {
+        #kickstarter-header {
+            height: 100vh;
+        }
+        .header-shadow {
+            height: 70vh;
+        }
+    }
+    @media all and (orientation:landscape) {
+        #kickstarter-header {
+            height: 200vh;
+        }
+        .header-shadow {
+            height: 120vh;
+        }
+    }
+    #kickstarter-header {
+        -webkit-transition: height 999999s;
+        -moz-transition: height 999999s;
+        transition: height 999999s;
+    }
+    .header-shadow {
+        -webkit-transition: height 999999s;
+        -moz-transition: height 999999s;
+        transition: height 999999s;
+    }
+</STYLE>
 <h4 style="color: white; font-size: 40px;">Hello world</h4>

--- a/fle_site/apps/main/static/kickstarter/kickstarter_parallax_template.html
+++ b/fle_site/apps/main/static/kickstarter/kickstarter_parallax_template.html
@@ -1,4 +1,12 @@
 <!-- {% load staticfiles%}     -->
+<STYLE type="text/css">
+    #kickstarter-header {
+        height: 100vh;
+    }
+    .header-shadow {
+        height: 70vh;
+    }
+</STYLE>
 <link rel="stylesheet" href="/static/css/parallax_main.css">
 <link rel="stylesheet" href="/static/css/parallax_normalize.css">
 <section id="slide-2">


### PR DESCRIPTION
@jamalex  sorry for the nonsense commit message(the file changes are actually minimum). I found a solution, which is to load different css styling depends on desktop or mobile, this PR also fixes the rotation problem. Let me know if you want the first section behave differently.