### PR TITLE
Support use of variables in redirect URLs, drawing from new RedirectVariable model

### DIFF
--- a/fle_site/apps/redirects/admin.py
+++ b/fle_site/apps/redirects/admin.py
@@ -2,7 +2,7 @@ from django.contrib import admin
 from django.contrib.auth.models import User
 from django.db import models
 
-from .models import RedirectRule, RedirectLogEntry
+from .models import RedirectRule, RedirectLogEntry, RedirectVariable
 
 
 class RedirectRuleAdmin(admin.ModelAdmin):
@@ -32,3 +32,10 @@ class RedirectLogEntryAdmin(admin.ModelAdmin):
     referrer.allow_tags = True
 
 admin.site.register(RedirectLogEntry, RedirectLogEntryAdmin)
+
+
+class RedirectVariableAdmin(admin.ModelAdmin):
+    list_display = ('name', 'value')
+    list_editable = ('value',)
+
+admin.site.register(RedirectVariable, RedirectVariableAdmin)

--- a/fle_site/apps/redirects/migrations/0001_initial.py
+++ b/fle_site/apps/redirects/migrations/0001_initial.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'RedirectRule'
+        db.create_table(u'redirects_redirectrule', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('slug', self.gf('django.db.models.fields.SlugField')(max_length=100)),
+            ('url', self.gf('django.db.models.fields.URLField')(max_length=200)),
+            ('login_required', self.gf('django.db.models.fields.BooleanField')(default=False)),
+            ('enabled', self.gf('django.db.models.fields.BooleanField')(default=True)),
+            ('override', self.gf('django.db.models.fields.BooleanField')(default=False)),
+            ('notes', self.gf('django.db.models.fields.TextField')(blank=True)),
+        ))
+        db.send_create_signal(u'redirects', ['RedirectRule'])
+
+        # Adding model 'RedirectLogEntry'
+        db.create_table(u'redirects_redirectlogentry', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('rule', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['redirects.RedirectRule'])),
+            ('timestamp', self.gf('django.db.models.fields.DateTimeField')()),
+            ('ip', self.gf('django.db.models.fields.CharField')(max_length=50, blank=True)),
+            ('referer', self.gf('django.db.models.fields.TextField')(blank=True)),
+            ('user_agent', self.gf('django.db.models.fields.TextField')(blank=True)),
+            ('user', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['auth.User'], null=True, blank=True)),
+        ))
+        db.send_create_signal(u'redirects', ['RedirectLogEntry'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'RedirectRule'
+        db.delete_table(u'redirects_redirectrule')
+
+        # Deleting model 'RedirectLogEntry'
+        db.delete_table(u'redirects_redirectlogentry')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'redirects.redirectlogentry': {
+            'Meta': {'object_name': 'RedirectLogEntry'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ip': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'referer': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'rule': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['redirects.RedirectRule']"}),
+            'timestamp': ('django.db.models.fields.DateTimeField', [], {}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'null': 'True', 'blank': 'True'}),
+            'user_agent': ('django.db.models.fields.TextField', [], {'blank': 'True'})
+        },
+        u'redirects.redirectrule': {
+            'Meta': {'object_name': 'RedirectRule'},
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'login_required': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'notes': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'override': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '100'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200'})
+        }
+    }
+
+    complete_apps = ['redirects']

--- a/fle_site/apps/redirects/migrations/0002_auto__add_redirectvariable.py
+++ b/fle_site/apps/redirects/migrations/0002_auto__add_redirectvariable.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'RedirectVariable'
+        db.create_table(u'redirects_redirectvariable', (
+            ('name', self.gf('django.db.models.fields.CharField')(max_length=50, primary_key=True)),
+            ('value', self.gf('django.db.models.fields.CharField')(max_length=150)),
+        ))
+        db.send_create_signal(u'redirects', ['RedirectVariable'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'RedirectVariable'
+        db.delete_table(u'redirects_redirectvariable')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'redirects.redirectlogentry': {
+            'Meta': {'object_name': 'RedirectLogEntry'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ip': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'referer': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'rule': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['redirects.RedirectRule']"}),
+            'timestamp': ('django.db.models.fields.DateTimeField', [], {}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'null': 'True', 'blank': 'True'}),
+            'user_agent': ('django.db.models.fields.TextField', [], {'blank': 'True'})
+        },
+        u'redirects.redirectrule': {
+            'Meta': {'object_name': 'RedirectRule'},
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'login_required': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'notes': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'override': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '100'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200'})
+        },
+        u'redirects.redirectvariable': {
+            'Meta': {'object_name': 'RedirectVariable'},
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'primary_key': 'True'}),
+            'value': ('django.db.models.fields.CharField', [], {'max_length': '150'})
+        }
+    }
+
+    complete_apps = ['redirects']

--- a/fle_site/apps/redirects/migrations/0003_auto__add_field_redirectlogentry_url.py
+++ b/fle_site/apps/redirects/migrations/0003_auto__add_field_redirectlogentry_url.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'RedirectLogEntry.url'
+        db.add_column(u'redirects_redirectlogentry', 'url',
+                      self.gf('django.db.models.fields.URLField')(default='', max_length=200, blank=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'RedirectLogEntry.url'
+        db.delete_column(u'redirects_redirectlogentry', 'url')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'redirects.redirectlogentry': {
+            'Meta': {'object_name': 'RedirectLogEntry'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ip': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'referer': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'rule': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['redirects.RedirectRule']"}),
+            'timestamp': ('django.db.models.fields.DateTimeField', [], {}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'null': 'True', 'blank': 'True'}),
+            'user_agent': ('django.db.models.fields.TextField', [], {'blank': 'True'})
+        },
+        u'redirects.redirectrule': {
+            'Meta': {'object_name': 'RedirectRule'},
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'login_required': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'notes': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'override': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '100'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200'})
+        },
+        u'redirects.redirectvariable': {
+            'Meta': {'object_name': 'RedirectVariable'},
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'primary_key': 'True'}),
+            'value': ('django.db.models.fields.CharField', [], {'max_length': '150'})
+        }
+    }
+
+    complete_apps = ['redirects']

--- a/fle_site/apps/redirects/models.py
+++ b/fle_site/apps/redirects/models.py
@@ -44,6 +44,7 @@ class RedirectLogEntry(models.Model):
     referer = models.TextField(blank=True)
     user_agent = models.TextField(blank=True)
     user = models.ForeignKey(User, blank=True, null=True)
+    url = models.URLField(blank=True)
 
     class Meta:
         verbose_name_plural = "Redirect log entries"
@@ -63,3 +64,9 @@ class RedirectLogEntry(models.Model):
             if request.user.is_authenticated():
                 self.user = request.user
         super(RedirectLogEntry, self).save(*args, **kwargs)
+
+
+class RedirectVariable(models.Model):
+    name = models.CharField(max_length=50, primary_key=True)
+    value = models.CharField(max_length=150)
+

--- a/fle_site/apps/redirects/views.py
+++ b/fle_site/apps/redirects/views.py
@@ -7,20 +7,12 @@ from django.shortcuts import get_object_or_404
 
 from .models import RedirectRule, RedirectLogEntry, RedirectVariable
 
-VARIABLE_REGEX = re.compile("%([A-Za-z0-9_]+)%")
-
-def _replace_variable(matchobj):
-    var_name = matchobj.group(1)
-    try:
-        return RedirectVariable.objects.get(name__iexact=var_name).value
-    except RedirectVariable.DoesNotExist:
-        return matchobj.group(0)
 
 def redirect(request, slug):
     rule = get_object_or_404(RedirectRule, slug=slug, enabled=True)
     if rule.login_required and not request.user.is_authenticated():
         return HttpResponseNotAllowed("Please login before using this redirect.")
-    url = re.sub(VARIABLE_REGEX, _replace_variable, rule.url)
+    url = rule.get_url()
     logentry = RedirectLogEntry(request=request, rule=rule, url=url)
     logentry.save()
     return HttpResponseRedirect(url)

--- a/fle_site/apps/redirects/views.py
+++ b/fle_site/apps/redirects/views.py
@@ -1,15 +1,27 @@
+import re
 import sys
 
 from django.conf import settings
 from django.http import HttpResponseRedirect, HttpResponseNotAllowed
 from django.shortcuts import get_object_or_404
 
-from .models import RedirectRule, RedirectLogEntry
+from .models import RedirectRule, RedirectLogEntry, RedirectVariable
+
+VARIABLE_REGEX = re.compile("%([A-Za-z0-9_]+)%")
+
+def _replace_variable(matchobj):
+    var_name = matchobj.group(1)
+    try:
+        return RedirectVariable.objects.get(name__iexact=var_name).value
+    except RedirectVariable.DoesNotExist:
+        return matchobj.group(0)
 
 def redirect(request, slug):
     rule = get_object_or_404(RedirectRule, slug=slug, enabled=True)
     if rule.login_required and not request.user.is_authenticated():
         return HttpResponseNotAllowed("Please login before using this redirect.")
-    logentry = RedirectLogEntry(request=request, rule=rule)
+    url = re.sub(VARIABLE_REGEX, _replace_variable, rule.url)
+    logentry = RedirectLogEntry(request=request, rule=rule, url=url)
     logentry.save()
-    return HttpResponseRedirect(rule.url)
+    return HttpResponseRedirect(url)
+


### PR DESCRIPTION
Example of use:

- Define a new variable at http://127.0.0.1:8000/admin/redirects/redirectvariable/ (e.g. with `name="SHORT_VERSION"`, `value="0.14"`)
- Define a redirect rule at http://127.0.0.1:8000/admin/redirects/redirectrule/ (e.g. with `url="http://field.learningequality.org/docs/%SHORT_VERSION%/en/"`)