### PR TITLE
Fixed docs links so people can find the docs and install KA Lite again.

### DIFF
--- a/fle_site/apps/ka_lite/templates/ka_lite/sections/download.html
+++ b/fle_site/apps/ka_lite/templates/ka_lite/sections/download.html
@@ -31,7 +31,7 @@
         </div>
         <div class="row">
           <div class="col-xs-12">
-            <a href="{% url 'user_guide_detail' 'latest' %}" class="btn btn-primary btn-md">
+            <a href="https://learningequality.org/r/docs-latest-install-guide" class="btn btn-primary btn-md">
               View the Installation Guide
             </a>  
           </div>

--- a/fle_site/apps/ka_lite/templates/ka_lite/sections/support.html
+++ b/fle_site/apps/ka_lite/templates/ka_lite/sections/support.html
@@ -32,7 +32,7 @@
 			<div class="col-sm-6">
 				<h3><img src="{% static 'img/ka-lite/faq.png' %}">&nbsp;Read the FAQ!</h3>
 				<p>Have a question? Chances are, you aren't the only one!  Our FAQ pages are the first place you should check to find a solution.  We have help on installations, deployments, tracking, and more.</p>
-				<p><a class="btn btn-primary btn-lg visible-xs" href="https://learningequality.org/docs/faq.html">Check the FAQ!</a></p>
+				<p><a class="btn btn-primary btn-lg visible-xs" href="https://learningequality.org/r/docs-latest-faq">Check the FAQ!</a></p>
 			</div><!-- End FAQ -->
 		</div>
 		<div class="row comm-btns hidden-xs">
@@ -40,7 +40,7 @@
 				<a class="btn btn-primary btn-lg" href="{% url 'user_guides' %}">Read the User Guides!</a>
 			</div>
 			<div class="col-sm-6">
-				<a class="btn btn-primary btn-lg" href="https://learningequality.org/docs/faq.html">Check the FAQ!</a>
+				<a class="btn btn-primary btn-lg" href="https://learningequality.org/r/docs-latest-faq">Check the FAQ!</a>
 			</div>
 		</div>
 

--- a/fle_site/apps/ka_lite/templates/ka_lite/sections/support.html
+++ b/fle_site/apps/ka_lite/templates/ka_lite/sections/support.html
@@ -23,9 +23,9 @@
 		<div class="row">
 			<!-- User Guides -->
 			<div class="col-sm-6">
-				<h3><img src="{% static 'img/ka-lite/faq.png' %}">&nbsp;Read the User Guides!</h3>
-				<p>KA Lite was designed to run in a wide variety of scenarios and fit a large number of use cases. See how you can use it best by exploring our user guides.</p>
-				<p><a class="btn btn-primary btn-lg visible-xs" href="{% url 'user_guides' %}">Read the User Guides!</a></p>
+				<h3><img src="{% static 'img/ka-lite/faq.png' %}">&nbsp;Read the User Manual!</h3>
+				<p>KA Lite was designed to run in a wide variety of scenarios. See how you can use it best by exploring our user manuals for admins, learners, and coaches.</p>
+				<p><a class="btn btn-primary btn-lg visible-xs" href="https://learningequality.org/r/docs-latest">Read the User Guides!</a></p>
 			</div><!-- End Guides -->
 
 			<!-- FAQ -->


### PR DESCRIPTION
With the recent namespacing of the docs by version and language, the old docs links broke, so nobody could reach the installer page.

I've created the following URL redirect rules:
- https://learningequality.org/r/docs-latest -> https://learningequality.org/docs/%SHORT_VERSION%/en/
- https://learningequality.org/r/docs-latest-install-guide -> https://learningequality.org/docs/%SHORT_VERSION%/en/installguide/install_main.html
- https://learningequality.org/r/docs-latest-faq -> https://learningequality.org/docs/%SHORT_VERSION%/en/faq.html

and this PR updates the links to point to these URLs.

(CC @MCGallaspy)