### PR TITLE
Fix for annoying layout bug on /kolibri/ page

### DIFF
--- a/fle_site/static/less/styles.less
+++ b/fle_site/static/less/styles.less
@@ -1046,3 +1046,9 @@ div.comm-btns.row {
 #contactModal {
     overflow-y: hidden !important;
 }
+
+
+// fix for 15px right-margin bug https://github.com/twbs/bootstrap/issues/9855
+.modal-open, .modal-open .navbar-fixed-top {
+    margin-right:0 !important;
+}


### PR DESCRIPTION

<img width="1037" alt="screen shot 2017-09-12 at 8 40 44 am" src="https://user-images.githubusercontent.com/163966/30327626-c046b3de-979a-11e7-8f60-a094380d11ae.png">

Bug:
```
  - Click on one of the modals near the bottom of the page
    Learn Create Share --> [  ] [  ]
                           [  ] [  ]
  - Modal shows but everything seems to move (shift 15px to the right)
```

Adding the css from this PR keeps things in place.

For more info see: https://github.com/twbs/bootstrap/issues/9855
might have been fixed in v3.2.0