### PR TITLE
Bump Django to latest 1.5 release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.5.1
+Django==1.5.12
 Pillow==2.4.0
 Pygments==1.6
 South==0.8.2


### PR DESCRIPTION
1.5.1 doesn't work as a .whl and is completely useless now because of changes in setuptools. Bump to 1.5.12 and everything seems to work...